### PR TITLE
Remove unused param in workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,5 +29,4 @@ jobs:
       - name: 'Publish to NPM'
         uses: JS-DevTools/npm-publish@v3
         with:
-          check-latest: true
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This fixes a simple mistake added in last PR. The addition does not affect the flow of PRs, etc. It just causes a warning in the workflow output.