### PR TITLE
Fix auto-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,6 +26,10 @@ jobs:
           npm ci
           npm test
 
+      - name: 'Build the package'
+        run: |
+          npm run build
+
       - name: 'Publish to NPM'
         uses: JS-DevTools/npm-publish@v3
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-npm/components",
-  "version": "0.0.10-beta",
+  "version": "0.0.12-beta",
   "description": "Universal Connect Project - Connect Widget Component",
   "keywords": [
     "fintech",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npx cross-env BROWSER=none && rollup -c",
+    "build": "rollup -c",
     "clean": "rm -rf dist && rm -f ucp-npm-*.tgz",
     "pack": "npm run clean && npm run build && npm pack",
     "test": "echo \"No test specified\" && exit 0"


### PR DESCRIPTION
This workflow was publishing a very empty package, which would result in errors when trying to consume it. The build process wasn't being run prior to publishing, and thus there was really nothing being published.