### PR TITLE
Rename provider to aggregator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-npm/components",
-  "version": "0.0.15-beta",
+  "version": "0.0.16-beta",
   "description": "Universal Connect Project - Connect Widget Component",
   "keywords": [
     "fintech",

--- a/src/connect/JobSchedule.jsx
+++ b/src/connect/JobSchedule.jsx
@@ -27,7 +27,7 @@ export const initialize = (member, updatedMember, config) => {
   }
 
   // sequential jobs
-  if (['mx_int', 'mx'].includes(member.provider)) {
+  if (['mx_int', 'mx'].includes(member.aggregator)) {
     if (config.include_identity === true || jobType === "aggregate_identity_verification") {
       jobs = [...jobs, { type: JOB_TYPES.IDENTIFICATION, status: JOB_STATUSES.PENDING }]
     }

--- a/src/connect/__tests__/JobSchedule-tests.jsx
+++ b/src/connect/__tests__/JobSchedule-tests.jsx
@@ -3,7 +3,7 @@ import { JOB_TYPES, JOB_STATUSES } from '../consts'
 import { VERIFY_MODE, AGG_MODE, HISTORY_MODE } from '../../connect/const/Connect'
 
 describe('JobSchedule.initialize', () => {
-  const nonAggregatingMember = { guid: 'MBR-1', is_being_aggregated: false, provider: 'mx' }
+  const nonAggregatingMember = { guid: 'MBR-1', is_being_aggregated: false, aggregator: 'mx' }
   const aggingMember = { guid: 'MBR-1', is_being_aggregated: true }
   const aggJob = { guid: 'JOB-1', job_type: JOB_TYPES.AGGREGATION }
   const extendedHistoryJob = { guid: 'JOB-2', job_type: JOB_TYPES.HISTORY }

--- a/src/connect/const/Connect.jsx
+++ b/src/connect/const/Connect.jsx
@@ -36,7 +36,7 @@ export const REFERRAL_SOURCES = {
 export const OAUTH_ERROR_REASONS = {
   CANCELLED: 'CANCELLED', // User cancelled/rejected/denied oauth
   DENIED: 'DENIED', // User couldn't authenticate
-  IMPEDED: 'IMPEDED', // User needs to resolve an issue at the provider
-  PROVIDER_ERROR: 'PROVIDER_ERROR', // Error from the oauth provider
+  IMPEDED: 'IMPEDED', // User needs to resolve an issue at the aggregator
+  PROVIDER_ERROR: 'PROVIDER_ERROR', // Error from the oauth aggregator
   SERVER_ERROR: 'SERVER_ERROR', // MX error
 }

--- a/src/connect/const/Connect.jsx
+++ b/src/connect/const/Connect.jsx
@@ -36,7 +36,7 @@ export const REFERRAL_SOURCES = {
 export const OAUTH_ERROR_REASONS = {
   CANCELLED: 'CANCELLED', // User cancelled/rejected/denied oauth
   DENIED: 'DENIED', // User couldn't authenticate
-  IMPEDED: 'IMPEDED', // User needs to resolve an issue at the aggregator
-  PROVIDER_ERROR: 'PROVIDER_ERROR', // Error from the oauth aggregator
+  IMPEDED: 'IMPEDED', // User needs to resolve an issue at the provider
+  PROVIDER_ERROR: 'PROVIDER_ERROR', // Error from the oauth provider
   SERVER_ERROR: 'SERVER_ERROR', // MX error
 }

--- a/src/connect/views/connecting/Connecting.jsx
+++ b/src/connect/views/connecting/Connecting.jsx
@@ -129,7 +129,7 @@ export const Connecting = props => {
         sendPostMessage('connect/memberConnected', {
           user_guid: currentMember.user_guid,
           member_guid: currentMember.guid,
-          provider: currentMember.provider,
+          aggregator: currentMember.aggregator,
         })
       } else if (hasAtriumAPI && isMobileWebview === true) {
         PostMessage.setWebviewUrl(`atrium://memberAdded/${currentMember.guid}`)
@@ -137,7 +137,7 @@ export const Connecting = props => {
         PostMessage.send('mxConnect:memberAdded', {
           member_guid: currentMember.guid,
           user_guid: currentMember.user_guid,
-          provider: currentMember.provider,
+          aggregator: currentMember.aggregator,
         })
       }
 

--- a/src/connect/views/credentials/Credentials.jsx
+++ b/src/connect/views/credentials/Credentials.jsx
@@ -243,7 +243,7 @@ export const Credentials = ({
       sendAnalyticsEvent({
         category: EventCategories.CONNECT,
         label: EventLabels.ENTER_CREDENTIALS,
-        provider: institution.provider,
+        aggregator: institution.aggregator,
         mode: connectConfig.mode,
         institution: institution.name,
         action: EventLabels.ENTER_CREDENTIALS + ' - ' + EventActions.END + ' (Submitted)',


### PR DESCRIPTION
This swaps "provider" for "aggregator".

The addition of a "provider" in the widget code must have been added by Sophtron, as the provider-related code does not exist in the MX Widget.